### PR TITLE
fix: enable code coverage reports to run on forks

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,16 +1,19 @@
-name: Run tests and code checks
+# This workflow generates test result and code coverage reports.
+name: Generate code reports
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_run:
+    workflows:
+      - Run tests and code checks
+    types:
+      - completed
+  workflow_dispatch:
 
 permissions:
-  # Required by mikepenz/action-junit-report
-  checks: write
   # Required by actions/checkout
   contents: read
+  # Required by mikepenz/action-junit-report
+  checks: write
   # Required by mi-kas/kover-report
   pull-requests: write
 
@@ -22,18 +25,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download test report
+        uses: dawidd6/action-download-artifact@v2
         with:
-          distribution: "temurin"
-          java-version: "17"
-          cache: "gradle"
+          name: junit-test-results
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
 
-      - name: Run test
-        run: ./gradlew check --no-daemon
-
-      - name: Publish test reports
+      - name: Publish test report
         uses: mikepenz/action-junit-report@v3
-        if: always()
         with:
           report_paths: |
             **/build/test-results/test/TEST-*.xml

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -7,7 +7,6 @@ on:
       - Run tests and code checks
     types:
       - completed
-  workflow_dispatch:
 
 permissions:
   # Required by actions/checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Run tests and code checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  # Required by actions/checkout
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "gradle"
+
+      - name: Run test
+        run: ./gradlew check --no-daemon
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v3
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-test-results
+          path: "**/build/test-results/test/TEST-*.xml"
+          retention-days: 1


### PR DESCRIPTION
Split the existing workflow into two; each workflow will have its own access token with appropriate scopes.

This will allow us to safely post coverage reports on PRs originating from forks, without needing to elevate token permissions or employ other such risky workarounds.

Fixes #6.

## Issue

https://github.com/line/geojson-kt/issues

## Summary

- **What** does this PR do?
- **Why** is it being opened?

## Changes

- **How** was this PR implemented?
- Please list major changes/additions.

## Notes / References

- Any relevant notes, materials, etc. (optional)

## Checklist

- [ ] Link to issue specified
- [ ] Implementation satisfies the stated objective(s)
- [ ] Test(s) added as appropriate
- [ ] Documentation created/updated